### PR TITLE
CD-142 Simplify HSL button variables based on primary colour

### DIFF
--- a/cd-button/cd-button.css
+++ b/cd-button/cd-button.css
@@ -1,24 +1,27 @@
 :root {
-  --cd-ocha-primary-color:  hsl(210, 70%, 56%);
-  --cd-ocha-darkbutton-default:  hsl(210, 70%, 56%);
-  --cd-ocha-lightbutton-default:  hsl(210, 70%, 81%);
-  --cd-ocha-button-hover:  hsl(210, 70%, 71%);
-  --cd-ocha-button-border:  hsl(210, 70%, 31%);
-  --cd-ocha-lightbutton-text:  hsl(210, 70%, 31%);
-  --cd-ocha-darkbutton-text:  #ffffff;
+  /* Define the Primary colour. */
+  /* Currently, --cd-ocha-blue */
+  /* --cd-primary-color: hsl(205, 98%, 36%); */
+
+  --cd-primary-color: hsl(210, 70%, 56%);
+  --cd-primary-color--lighter:  hsl(210, 70%, 71%);
+  --cd-primary-color--darker:  hsl(210, 70%, 31%);
 }
 
-.dark {
-  background-color: var(--cd-ocha-primary-color);
+/* Backgrounds */
+.cd-background--dark {
+  background-color: var(--cd-ocha-blue);
+  color: var(--cd-white);
 }
 
-.dark,
-.light {
+.cd-background--dark,
+.cd-background--light {
   text-align: center;
   padding: 1rem;
   margin-bottom: 3rem;
 }
 
+/* Default button */
 .cd-button {
   -webkit-appearance: none;
   border-radius: 3px;
@@ -28,55 +31,44 @@
   font-size: 1rem;
   /*transition: background 0.3s ease;*/
   width: auto;
-  background-color: var(--cd-ocha-lightbutton-default);
-  color: var(--cd-ocha-lightbutton-text);
-}
-
-.cd-button--lightstyle {
-  background: var(--cd-ocha-light-blue);
+  background-color: var(--cd-primary-color);
   color: var(--cd-white);
-}
-
-.cd-button--small {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.8rem;
-  font-weight: 400;
-}
-
-.cd-button--icon {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 }
 
 .cd-button:hover,
 .cd-button:focus {
-  background-color: var(--cd-ocha-button-hover);
+  background-color: var(--cd-primary-color--lighter);
 }
 
 .cd-button:focus {
-  outline: 0 solid var(--cd-ocha-blue);
-  border: 2px solid var(--cd-ocha-button-border);
+  /* We remove the outline because we are adding a border. */
+  outline: 0 solid var(--cd-primary-color--lighter);
+  border: 2px solid var(--cd-primary-color--darker);
 }
 
-.cd-button--style {
-  background: var(--cd-ocha-blue);
-  color: var(--cd-white);
+.cd-background--dark .cd-button {
+  --cd-primary-color: hsl(210, 70%, 81%);
+  background-color: var(--cd-primary-color);
+  color: var(--cd-primary-color--darker);
 }
 
-.cd-button--style:hover {
-  background: var(--cd-button-hover);
-  color: var(--cd-white);
+.cd-background--dark .cd-button:hover {
+  background-color: var(--cd-primary-color--lighter);
 }
 
-.cd-button--lightstyle:hover {
-  background: var(--cd-button-hover);
-  color: var(--cd-white);
-}
+.cd-button--style {}
 
-.cd-button--style:focus {
-  background: var(--cd-button-focus);
-  color: var(--cd-white);
+.cd-button--style:hover,
+.cd-button--style:focus {}
+
+.cd-button--style:focus {}
+
+
+/* Utility classes */
+.cd-button--small {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 400;
 }
 
 .cd-button--bold {
@@ -88,6 +80,12 @@
 }
 
 /* Some buttons have SVG icons */
+.cd-button--icon {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .cd-button--icon svg {
   fill: var(--cd-white);
   width: 2rem;
@@ -106,6 +104,7 @@
   fill: var(--cd-white);
 }
 
+
 .cd-button--export {
   background: var(--cd-mid-grey);
   color: var(--cd-white);
@@ -114,4 +113,8 @@
 .cd-button--export:hover,
 .cd-button--export:focus {
   background: var(--cd-dark-grey);
+}
+
+.cd-button--export:focus {
+  outline: 3px solid var(--cd-ocha-blue);
 }

--- a/cd-button/cd-button.css
+++ b/cd-button/cd-button.css
@@ -31,12 +31,13 @@
   font-size: 1rem;
   /*transition: background 0.3s ease;*/
   width: auto;
-  background-color: var(--cd-primary-color);
   color: var(--cd-white);
+  background-color: var(--cd-primary-color);
 }
 
 .cd-button:hover,
 .cd-button:focus {
+  color: var(--cd-white);
   background-color: var(--cd-primary-color--lighter);
 }
 
@@ -54,6 +55,12 @@
 
 .cd-background--dark .cd-button:hover {
   background-color: var(--cd-primary-color--lighter);
+}
+
+/* When it's an anchor styled as a button */
+a.cd-button {
+  text-decoration: none;
+  cursor: pointer;
 }
 
 .cd-button--style {}

--- a/cd-button/cd-button.html
+++ b/cd-button/cd-button.html
@@ -5,109 +5,110 @@
   <div class="cd-container">
 
 
-<div class="dark">
-    <button type="button" class="cd-button">
-      <span class="cd-button__text">Button A</span>
-    </button>
+    <div class="cd-background--light">
 
-    <p></p>
+      <p>These are button styles on a white background</p>
 
-    <button type="button" class="cd-button cd-button--small">
-      <span class="cd-button__text">Button B</span>
-    </button>
+      <button type="button" class="cd-button">
+        <span class="cd-button__text">Button A</span>
+      </button>
 
-    <p></p>
+      <p></p>
 
-    <button type="button" class="cd-button cd-button--lightstyle cd-button--small">
-      <span class="cd-button__text">Button C</span>
-    </button>
+      <button type="button" class="cd-button cd-button--small">
+        <span class="cd-button__text">Button B</span>
+      </button>
 
-    <p></p>
+      <p></p>
 
-    <button type="button" class="cd-button cd-button--style">
-      <span class="cd-button__text">Button D</span>
-    </button>
+      <button type="button" class="cd-button cd-button--style cd-button--small">
+        <span class="cd-button__text">Button C</span>
+      </button>
 
-    <p></p>
+      <p></p>
 
-    <button type="button" class="cd-button cd-button--style cd-button--bold cd-button--uppercase">
-      <span class="cd-button__text">Button E</span>
-    </button>
+      <button type="button" class="cd-button cd-button--style">
+        <span class="cd-button__text">Button D</span>
+      </button>
 
-    <p></p>
+      <p></p>
 
-    <button type="button" class="cd-button cd-button--style cd-button--icon">
-      <svg class="cd-icon cd-icon--creative-commons">
-        <use xlink:href="#cd-icon--creative-commons"></use>
-      </svg>
-      <span class="cd-button__text">Button F</span>
-    </button>
+      <button type="button" class="cd-button cd-button--style cd-button--bold cd-button--uppercase">
+        <span class="cd-button__text">Button E</span>
+      </button>
 
-    <p></p>
+      <p></p>
 
+      <button type="button" class="cd-button cd-button--style cd-button--icon">
+        <svg class="cd-icon cd-icon--creative-commons">
+          <use xlink:href="#cd-icon--creative-commons"></use>
+        </svg>
+        <span class="cd-button__text">Button F</span>
+      </button>
 
-    <button type="button" class="cd-button cd-button--export cd-button--icon">
-      <span class="cd-button__text">Export</span>
-      <svg class="cd-icon cd-icon--arrow-down">
-        <use xlink:href="#cd-icon--arrow-down"></use>
-      </svg>
-    </button>
-
-    <p></p>
-
-</div>
-
-<div class="light">
-    <button type="button" class="cd-button">
-      <span class="cd-button__text">Button A</span>
-    </button>
-
-    <p></p>
-
-    <button type="button" class="cd-button cd-button--small">
-      <span class="cd-button__text">Button B</span>
-    </button>
-
-    <p></p>
-
-    <button type="button" class="cd-button cd-button--style cd-button--small">
-      <span class="cd-button__text">Button C</span>
-    </button>
-
-    <p></p>
-
-    <button type="button" class="cd-button cd-button--style">
-      <span class="cd-button__text">Button D</span>
-    </button>
-
-    <p></p>
-
-    <button type="button" class="cd-button cd-button--style cd-button--bold cd-button--uppercase">
-      <span class="cd-button__text">Button E</span>
-    </button>
-
-    <p></p>
-
-    <button type="button" class="cd-button cd-button--style cd-button--icon">
-      <svg class="cd-icon cd-icon--creative-commons">
-        <use xlink:href="#cd-icon--creative-commons"></use>
-      </svg>
-      <span class="cd-button__text">Button F</span>
-    </button>
-
-    <p></p>
+      <p></p>
 
 
-    <button type="button" class="cd-button cd-button--export cd-button--icon">
-      <span class="cd-button__text">Export</span>
-      <svg class="cd-icon cd-icon--arrow-down">
-        <use xlink:href="#cd-icon--arrow-down"></use>
-      </svg>
-    </button>
+      <button type="button" class="cd-button cd-button--export cd-button--icon">
+        <span class="cd-button__text">Export</span>
+        <svg class="cd-icon cd-icon--arrow-down">
+          <use xlink:href="#cd-icon--arrow-down"></use>
+        </svg>
+      </button>
 
-    <p></p>
+      <p></p>
 
-  </div>
+    </div>
+
+
+    <div class="cd-background--dark">
+
+      <p>These are buttons on a darker background</p>
+
+        <button type="button" class="cd-button">
+          <span class="cd-button__text">Button A</span>
+        </button>
+
+        <p></p>
+
+        <button type="button" class="cd-button cd-button--small">
+          <span class="cd-button__text">Button B</span>
+        </button>
+
+        <p></p>
+
+        <button type="button" class="cd-button cd-button--style">
+          <span class="cd-button__text">Button D</span>
+        </button>
+
+        <p></p>
+
+        <button type="button" class="cd-button cd-button--style cd-button--bold cd-button--uppercase">
+          <span class="cd-button__text">Button E</span>
+        </button>
+
+        <p></p>
+
+        <button type="button" class="cd-button cd-button--style cd-button--icon">
+          <svg class="cd-icon cd-icon--creative-commons">
+            <use xlink:href="#cd-icon--creative-commons"></use>
+          </svg>
+          <span class="cd-button__text">Button F</span>
+        </button>
+
+        <p></p>
+
+
+        <button type="button" class="cd-button cd-button--export cd-button--icon">
+          <span class="cd-button__text">Export</span>
+          <svg class="cd-icon cd-icon--arrow-down">
+            <use xlink:href="#cd-icon--arrow-down"></use>
+          </svg>
+        </button>
+
+        <p></p>
+
+    </div>
 
 
   </div>

--- a/cd-button/cd-button.html
+++ b/cd-button/cd-button.html
@@ -39,6 +39,12 @@
 
       <p></p>
 
+      <a type="button" class="cd-button cd-button--bold">
+        Anchor styled as a button
+      </a>
+
+      <p></p>
+
       <button type="button" class="cd-button cd-button--style cd-button--icon">
         <svg class="cd-icon cd-icon--creative-commons">
           <use xlink:href="#cd-icon--creative-commons"></use>

--- a/cd-ocha/cd-ocha.css
+++ b/cd-ocha/cd-ocha.css
@@ -1,1 +1,16 @@
 /* See https://github.com/UN-OCHA/common_design/blob/master/sass/cd/cd-header/_cd-ocha.scss */
+
+.cd-button.cd-ocha-dropdown__see-all {
+  --cd-primary-color: hsl(210, 70%, 81%);
+  display: block;
+  width: 100%;
+  font-size: 0.875rem;
+  font-weight: 700;
+  padding: 0.75rem;
+  background-color: var(--cd-primary-color);
+  color: var(--cd-primary-color--darker);
+}
+
+.cd-button.cd-ocha-dropdown__see-all:hover {
+  background-color: var(--cd-primary-color--lighter);
+}

--- a/cd-ocha/cd-ocha.html
+++ b/cd-ocha/cd-ocha.html
@@ -5,6 +5,8 @@
   <title></title>
   <link rel=stylesheet href="../cd-base.css" type="text/css" media=screen>
   <link rel=stylesheet href="https://demo.commondesign-unocha-org.ahconu.org/themes/contrib/common_design/css/styles.css" type="text/css" media=screen>
+  <link rel=stylesheet href="../cd-button/cd-button.css" type="text/css" media=screen>
+  <link rel=stylesheet href="cd-ocha.css" type="text/css" media=screen>
 
   <script>document.documentElement.className = document.addEventListener ? "js" : "no-js";</script>
 </head>
@@ -50,7 +52,7 @@
                     </ul>
                   </div>
                   <div class="cd-ocha-dropdown__section">
-                    <a class="cd-ocha-dropdown__see-all" href="https://www.unocha.org/ocha-digital-services" target="_blank" rel="noopener">See all</a>
+                    <a class="cd-button cd-button--uppercase cd-ocha-dropdown__see-all" href="https://www.unocha.org/ocha-digital-services" target="_blank" rel="noopener">See all</a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
This branches off #19 

I've refactored the variables based on the relationship of the colour for hover and focus to the primary colour.
![button-vs-figma](https://user-images.githubusercontent.com/1835923/91458979-6bcbc700-e886-11ea-8cd2-387a550d2db1.png)

and use OCHA Services "See all" button as a test.
![ocha-services](https://user-images.githubusercontent.com/1835923/91459351-d977f300-e886-11ea-87c1-eb09fc90af93.png)

What's interesting to note here is the use of border instead of outline for the focus increases the width and height of existing button or anchor elements (because a border is also set on the default button) which might not be the desired result. Perhaps we should consider using outline and not worrying about the visually rounded corners for visual feedback of the focus state.
