### PR TITLE
CD-275: grid defaults

### DIFF
--- a/cd-grid/cd-grid.css
+++ b/cd-grid/cd-grid.css
@@ -1,9 +1,12 @@
 .cd-grid > * {
   margin-bottom: 1rem;
-  background: var(--cd-grey--light);
 }
 
 /* Testing Aid */
+.cd-grid > * {
+  /* background: lightgray; */
+}
+
 .cd-grid-2-col > * {
   /* background: lightpink; */
 }

--- a/cd-grid/cd-grid.css
+++ b/cd-grid/cd-grid.css
@@ -29,7 +29,6 @@
 
   .cd-grid > * {
     flex: 0 0 48%;
-    display: flex;
   }
 
   .cd-grid-2-col.cd-grid--grow > *:last-child {


### PR DESCRIPTION
# CD-275

I moved the gray background to a dedicated testing rule like the other three.

I also removed `display: flex` from grid items. I think this _might_ have made sense in IE11 or something, but since it wasn't being unset in the `@supports (display: grid)` it was causing me some confusion when implementing CD Grid on HID, with testing in Chrome/FF.

I don't consider these breaking changes since my workaround on HID was setting `display: block` on elements that should have been that way in the first place.